### PR TITLE
added antsnetct_version to config and setup

### DIFF
--- a/configs/SCAN
+++ b/configs/SCAN
@@ -1,3 +1,4 @@
 bids_in="/project/wolk_4/SCAN/bids"
 t1pre_out="/project/wolk_4/SCAN/bids/derivatives/T1wPreprocessing_051"
-antsnetct_dir="/project/wolk_4/SCAN/bids/derivatives/antsnetct_054"
+antsnetct_version="0.5.4"
+antsnetct_dir="/project/wolk_4/SCAN/bids/derivatives/antsnetct_${antsnetct_version//.}"

--- a/configs/hup6
+++ b/configs/hup6
@@ -1,3 +1,4 @@
 bids_in="/project/ftdc_volumetric/fw_bids"
 t1pre_dir="/project/ftdc_pipeline/data/T1wPreprocessing_051"
-antsnetct_dir="/project/ftdc_pipeline/data/antsnetct_054"
+antsnetct_version="0.5.4"
+antsnetct_dir="/project/ftdc_pipeline/data/antsnetct_${antsnetct_version//.}"

--- a/configs/hup6_xa60
+++ b/configs/hup6_xa60
@@ -1,3 +1,4 @@
 bids_in="/project/ftdc_volumetric/hup6_xa60/bids"
 t1pre_dir="/project/ftdc_pipeline/data/T1wPreprocessing_051"
-antsnetct_dir="/project/ftdc_pipeline/data/antsnetct_054"
+antsnetct_version="0.5.4"
+antsnetct_dir="/project/ftdc_pipeline/data/antsnetct_${antsnetct_version//.}"

--- a/wrap_submit_antsnetct.sh
+++ b/wrap_submit_antsnetct.sh
@@ -10,16 +10,15 @@ if [[ $# -lt 2 ]]; then
    echo "   assumes T1-weighted images in bids_in have been brain masked with neck trim using " 
    echo "       T1wPreprocessing done for brain masking with neck trimming completed in t1pre_dir"
    echo "  " 
-   echo "   config specifies bids_in, t1pre_dir, and antsnetct_dir"
+   echo "   config specifies bids_in, t1pre_dir, antsnetct_version, and antsnetct_dir"
    echo "---"
    echo "   if queue specified, jobs are submitted to it. Default: ftdc_normal"
    echo "---"
    echo "Notes: "
    echo " -uses ADNINormalAgingANTs as template (TEMPLATEFLOW_HOME set inside submit_antsnetct.sh)"
-   echo " -uses antsnetct version 0.5.4 "
    echo " -uses do-ants-atropos-n4 option "
    echo " "
-   exit 1
+  #  exit 1
 fi
 
 subseslist=$1
@@ -32,6 +31,17 @@ fi
 
 source $config
 
+echo ""
+echo " -original BIDS data from ${bids_in} "
+echo ""
+echo " -using brain masks from ${t1pre_dir} "
+echo ""
+echo " -using antsnetct version ${antsnetct_version} "
+echo ""
+echo " output goes to ${antsnetct_dir} " 
+echo ""
+
+exit 1
 for i in `cat $subseslist`; do 
     sub=$(echo $i | cut -d ',' -f1)
     ses=$(echo $i | cut -d ',' -f2)
@@ -42,7 +52,7 @@ for i in `cat $subseslist`; do
         -m 16000 \
         -n 4 \
         -o $antsnetct_dir \
-        -v 0.5.4 \
+        -v $antsnetct_version \
         -- \
         --participant $sub \
         --session $ses \

--- a/wrap_submit_antsnetct.sh
+++ b/wrap_submit_antsnetct.sh
@@ -41,7 +41,6 @@ echo ""
 echo " output goes to ${antsnetct_dir} " 
 echo ""
 
-exit 1
 for i in `cat $subseslist`; do 
     sub=$(echo $i | cut -d ',' -f1)
     ses=$(echo $i | cut -d ',' -f2)


### PR DESCRIPTION
added antsnetct_version variable to each of the existing config files. The variable for FTDC, it's now used to set the antsnetct output directory in the configs (variable antsnetct_dir). The variable is also used in the wrap_submit_antsnetct.sh (and forthcoming wrap_submit_antsnetct_parcellate.sh) to pass to antsnetct for both the segmentation and parcellate.